### PR TITLE
Automaattisen otsikoinnin silottelua

### DIFF
--- a/sankaristoorit-backend/package-lock.json
+++ b/sankaristoorit-backend/package-lock.json
@@ -973,8 +973,7 @@
     "@types/node": {
       "version": "14.14.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
-      "dev": true
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1549,6 +1548,11 @@
         }
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -1727,6 +1731,29 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.1",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
     },
     "chokidar": {
       "version": "3.4.3",
@@ -2037,6 +2064,22 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -2240,6 +2283,20 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
     "domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -2255,6 +2312,23 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -2334,6 +2408,11 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3451,6 +3530,31 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -5054,8 +5158,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.foreach": {
       "version": "4.5.0",
@@ -5606,6 +5709,14 @@
         "console-control-strings": "~1.1.0",
         "gauge": "~2.7.3",
         "set-blocking": "~2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
       }
     },
     "number-is-nan": {

--- a/sankaristoorit-backend/package.json
+++ b/sankaristoorit-backend/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "bcrypt": "^5.0.0",
+    "cheerio": "^1.0.0-rc.3",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/sankaristoorit-backend/routers/ReadingTip.js
+++ b/sankaristoorit-backend/routers/ReadingTip.js
@@ -54,6 +54,10 @@ tipsRouter.get('/get_title/:url', async (req, res) => {
       throw 'not found'
     }
     const page = await fetch(url)
+    const contentType = page.headers.get('content-type')
+    if (contentType.indexOf('text/html') < 0 && contentType.indexOf('application/xml+xhtml') < 0) {
+      throw 'wrong content-type header'
+    }
     const text = await page.text()
     const $ = cheerio.load(text)
     const title = $('title').text()

--- a/sankaristoorit-backend/routers/ReadingTip.js
+++ b/sankaristoorit-backend/routers/ReadingTip.js
@@ -4,6 +4,7 @@ const User = require('../models/User')
 const jwt = require('jsonwebtoken')
 const { validURL } = require('../utils/middleware')
 const fetch = require('node-fetch')
+const cheerio = require('cheerio')
 
 const regexp = new RegExp('^(https?:\\/\\/)?'+ // protocol
 '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{1,}|'+ // domain name
@@ -54,8 +55,9 @@ tipsRouter.get('/get_title/:url', async (req, res) => {
     }
     const page = await fetch(url)
     const text = await page.text()
-    const title = text.match(/<title>([^<]*)<\/title>/)
-    res.json({ title: title[1] })
+    const $ = cheerio.load(text)
+    const title = $('title').text()
+    res.json({ title: title })
   } catch (e) {
     res.status(404).end('Title not found')
   }

--- a/sankaristoorit-backend/tests/tips.test.js
+++ b/sankaristoorit-backend/tests/tips.test.js
@@ -283,6 +283,12 @@ describe('getting title automatically works', () => {
       .get('/tips/get_title/' + encodeURIComponent('asd.fixu'))
       .expect(404)
   })
+
+  test('404 is returned when content type is wrong', async () => {
+    await api
+      .get('/tips/get_title/' + encodeURIComponent('https://www.google.com/favicon.ico'))
+      .expect(404)
+  })
 })
 
 afterAll(() => {

--- a/sankaristoorit-ui/src/App.js
+++ b/sankaristoorit-ui/src/App.js
@@ -24,6 +24,9 @@ const App = () => {
   const [newUrl, setNewUrl] = useState('')
   const [errorMsgs, setErrorMsgs] = useState([])
 
+  const [fetchingUrl, setFetchingUrl] = useState(false)
+  const [autotitled, setAutotitled] = useState(false)
+
   useEffect(() => {
     tipService
       .getAll()
@@ -49,15 +52,19 @@ const App = () => {
   }
 
   const handleTitleChange = (event) => {
+    setAutotitled(false)
     setNewTitle(event.target.value)
   }
 
   const handleUrlChange = async (event) => {
     const url = event.target.value
     setNewUrl(url)
-    if ((!newTitle || newTitle.length < 1) && url) {
+    if ((!newTitle || newTitle.length < 1 || autotitled) && url) {
+      setFetchingUrl(true)
       const searchTitle = await tipService.get_title(url)
+      setFetchingUrl(false)
       if (url === event.target.value) {
+        setAutotitled(true)
         setNewTitle(searchTitle)
       }
     }
@@ -200,6 +207,7 @@ const App = () => {
             <TipForm addTip={addTip} newTitle={newTitle}
               handleTitleChange={handleTitleChange} newUrl={newUrl}
               handleUrlChange={handleUrlChange}
+              fetchingUrl={fetchingUrl}
               disabled={user === null} />
             <TipList tips={tips}
               deleteTip={deleteTip}

--- a/sankaristoorit-ui/src/App.js
+++ b/sankaristoorit-ui/src/App.js
@@ -53,10 +53,13 @@ const App = () => {
   }
 
   const handleUrlChange = async (event) => {
-    setNewUrl(event.target.value)
-    if ((!newTitle || newTitle.length < 1) && event.target.value) {
-      const searchTitle = await tipService.get_title(event.target.value)
-      setNewTitle(searchTitle)
+    const url = event.target.value
+    setNewUrl(url)
+    if ((!newTitle || newTitle.length < 1) && url) {
+      const searchTitle = await tipService.get_title(url)
+      if (url === event.target.value) {
+        setNewTitle(searchTitle)
+      }
     }
   }
 

--- a/sankaristoorit-ui/src/components/TipForm.js
+++ b/sankaristoorit-ui/src/components/TipForm.js
@@ -23,6 +23,9 @@ const TipForm = (props) =>
             disabled={props.disabled} />
         </Control>
       </Field>
+      {!props.disabled && props.fetchingUrl &&
+        <progress className='progress is-small'></progress>
+      }
       <Control>
         <Button id="create-button" type="submit" color="primary" disabled={props.disabled}>Create</Button>
       </Control>


### PR DESCRIPTION
Kohokohtia:

### Backend

- Ekstrahoidaan title regexin sijaan DOMia parsimalla, vältetään näin myös ilmaiseksi entiteettijäänteet kuten &amp;amp;
- Ei vaivauduta ei-HTML -tyyppisten resurssien kanssa, vaan heittäydytään ulos aiemmin

### Frontend

- Race condition korjattu, muutettaessa urlia api-kutsun ollessa liikkeellä ei tule vanha title kummittelemaan title-kenttään
- Edistysindikaattori mallia epämääräinen/rullaava api-kutsun aikana
- Jos uusi vinkki on autotitlattu eikä käyttäjä ole muokannut titleä ja linkkiin kosketaan, autotitlataan taas uusi title. Kätevää.